### PR TITLE
Add UI update when clicking candidate

### DIFF
--- a/src/conversion.cpp
+++ b/src/conversion.cpp
@@ -416,6 +416,7 @@ public:
 
     void select(fcitx::InputContext *) const override {
         anthy_->actionSelectCandidate(idx_);
+        anthy_->updateUI();
     }
 
 private:


### PR DESCRIPTION
Without UI update here, UI doesn't be updated when selecting candidate with mouse click.

It seems that UI update needs to be called on the IM side when selecting candidate.

I referred to [fcitx5-chinese-addons](https://github.com/fcitx/fcitx5-chinese-addons).
https://github.com/fcitx/fcitx5-chinese-addons/blob/d5ea6102f673f3fcb4e7de750a2658523f980332/im/pinyin/pinyin.cpp#L234-L247
https://github.com/fcitx/fcitx5-chinese-addons/blob/d5ea6102f673f3fcb4e7de750a2658523f980332/im/pinyin/pinyin.cpp#L439-L453
