### PR TITLE
replace uint with unsigned int

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -28,11 +28,11 @@ bool key_is_keypad(const fcitx::Key &key);
 std::string keypad_to_string(const fcitx::KeyEvent &key);
 void launch_program(std::string command);
 
-bool surrounding_get_safe_delta(uint from, uint to, int32_t *delta);
+bool surrounding_get_safe_delta(unsigned int from, unsigned int to, int32_t *delta);
 
 bool surrounding_get_anchor_pos_from_selection(
     const std::string &surrounding_text, const std::string &selected_text,
-    uint cursor_pos, uint *anchor_pos);
+    unsigned int cursor_pos, unsigned int *anchor_pos);
 
 inline char get_ascii_code(const fcitx::Key &key) {
     auto chr = fcitx::Key::keySymToUnicode(key.sym());


### PR DESCRIPTION
`uint` is not a standard type name

fixes building against musl libc which does not provide non-standard type aliases